### PR TITLE
fix dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,11 @@
   "dependencies": {
     "eslint-plugin-import": "^2.16.0",
     "jquery": "^3.3.1",
-    "react": "^16.8.3",
-    "react-dom": "^16.8.3",
     "velocity-animate": "^1.5.2"
+  },
+  "peerDependencies": {
+    "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",


### PR DESCRIPTION
Fix: Resolve incorrect React dependency issue

This PR addresses an issue in the `package.json` where `react` was listed as a regular dependency (`dependencies`). This was incorrect because this library depends on React being present in the consuming project but should not impose its own version.

The implemented solution is to move `react` to the `peerDependencies` section. This has the following effects:

- **Prevents redundant React installation:** Projects that already have React as a dependency will not install an additional copy.
- **Clarifies responsibility:** Clearly indicates that the consuming project must have React installed.
- **Reduces potential conflicts:** Minimizes the risks of having multiple versions of React in the dependency tree.

Review of this change is recommended to ensure its correct implementation.